### PR TITLE
Add `smart_search` to search for keyword based on context (or not)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,17 @@ Fail CI if a keyword is found in any of the changed files.
 
 | Input        | Description                                                                                            | Default Value   |
 |--------------|--------------------------------------------------------------------------------------------------------|-----------------|
-| keyword      | The keyword to search for in the file changes.                                                         | `DO_NOT_SUBMIT` |
+| keyword      | The keyword to search for in the file changes. This parameter supports regex.                          | `DO_NOT_SUBMIT` |
 | should_fail  | If the Github Action should fail if `keyword` is found.                                                | `true`          |
 | smart_search | If the `keyword` should be searched within comments (smart), or as-is.                                 | `true`          |
 | check_list   | A comma-separated list of regex-supported files to search for the keyword in                           | `"*"`           |
 | ignore_list  | A comma-seperated list of regex-supported files to NOT search. Takes precedence over the `check_list`. | `""`            |
 
-_**Note:** The `check_list` and `ignore_list` parameters should be wrapped in quotes if using wildcards._
+_**Note:** The `check_list`, `ignore_list`, and `keyword` parameters should be wrapped in quotes if using wildcards or special regex-matching characters._
 
 ## Example Usages
 
-### Use Case: Checking every modified file
+### Use Case: Default usage
 On a run without any parameters set, this performs a check for the default keyword (`DO_NOT_SUBMIT`) on **all** files that were modified. 
 No files are ignored.
 If any instances are found, the action will fail.
@@ -38,9 +38,6 @@ jobs:
 ```
 
 ### Use Case: Checking for files based on file extensions
-The following checks in `.go`, `.proto`, and `go.mod` files for the default keyword (`DO_NOT_SUBMIT`). 
-No files are ignored.
-If any instances are found, the action will fail.
 ```yaml
 name: Run Do Not Submit Action
 on:
@@ -58,12 +55,11 @@ jobs:
     - name: Run do-not-submit action
       uses: infocus7/do-not-submit-action@latest
       with:
+        # Search for the keyword in all files with the extensions `go` and `proto`, as well as `go.mod` files.
         check_list: '"*.go,*.proto,go.mod"'
 ```
 
 ### Use Case: Checking for ANY instance of the keyword
-The following checks for the default keyword (`DO_NOT_SUBMIT`) in all files that were modified.
-Since `smart_search` is set to `false`, the keyword is searched as-is regardless of the file type.
 ```yaml
 name: Run Do Not Submit Action
 on:
@@ -81,14 +77,11 @@ jobs:
     - name: Run do-not-submit action
       uses: infocus7/do-not-submit-action@latest
       with:
+        # Search for the keyword as-is, regardless of the file extension.
         smart_search: 'false'
 ```
 
-### Use Case: Specific searches
-The following code searches for the keyword `TODO`.
-All files in the `data` folder, as well as `go.mod` files are searched. 
-The files `data/file_1` and `data/file_2` are ignored, and therefore not searched.
-Since `should_fail` is set to `false`: if any instances of the keyword are found, the Github Action will still pass with a warning.
+### Use Case: Advanced searches
 ```yaml
 name: Run Do Not Submit Action
 on:
@@ -107,13 +100,19 @@ jobs:
     - name: Run do-not-submit action
       uses: infocus7/do-not-submit-action@latest
       with:
-        keyword: 'TODO'
+        # Search for both `EXAMPLE` and `DO_NOT_SUBMIT`
+        keyword: '"EXAMPLE|DO_NOT_SUBMIT"'
+        # Search for the keyword in all files in the `data` folder, as well as `go.mod` files
         check_list: '"data/*,go.mod"'
+        # Ignore the files `data/file_1` and `data/file_2`
         ignore_list: '"data/file_1,data/file_2"'
+        # Succeed and warn in the action if any instances of the keyword are found
         should_fail: 'false'
 ```
 
 ## Limitations
 - The action does not support searching for a keyword in a multi-line comment.
-  - A workaround to this is using the `smart_search: false` parameter as shown in the [Checking For Any Instance example](#use-case-checking-for-any-instance-of-the-keyword).
+  - A workaround to this is using the `smart_search: false` parameter as shown in [Checking For Any Instance](#use-case-checking-for-any-instance-of-the-keyword).
   - This may not be a good workaround for all cases.
+- Due to the nature of regex commands, any parameters using wildcards or special characters (ex. '|'), should be wrapped in quotes.
+  - This is shown in the [Checking For Files Based On File Extensions](#use-case-checking-for-files-based-on-file-extensions) as well as in [Advanced Searches](#use-case-advanced-searches).

--- a/README.md
+++ b/README.md
@@ -3,12 +3,13 @@ Fail CI if a keyword is found in any of the changed files.
 
 ## Action Definition
 
-| Input   | Description | Default Value |
-|----|----|----|
-| keyword  | The keyword to search for in the file changes. | `DO_NOT_SUBMIT` |
-| should_fail | If the Github Action should fail if `keyword` is found. | `true` |
-| check_list  | A comma-separated list of regex-supported files to search for the keyword in | `"*"` |
-| ignore_list | A comma-seperated list of regex-supported files to NOT search. Takes precedence over the `check_list`. | `""` |
+| Input        | Description                                                                                            | Default Value   |
+|--------------|--------------------------------------------------------------------------------------------------------|-----------------|
+| keyword      | The keyword to search for in the file changes.                                                         | `DO_NOT_SUBMIT` |
+| should_fail  | If the Github Action should fail if `keyword` is found.                                                | `true`          |
+| smart_search | If the `keyword` should be searched within comments (smart), or as-is.                                 | `true`          |
+| check_list   | A comma-separated list of regex-supported files to search for the keyword in                           | `"*"`           |
+| ignore_list  | A comma-seperated list of regex-supported files to NOT search. Takes precedence over the `check_list`. | `""`            |
 
 _**Note:** The `check_list` and `ignore_list` parameters should be wrapped in quotes if using wildcards._
 
@@ -18,7 +19,7 @@ _**Note:** The `check_list` and `ignore_list` parameters should be wrapped in qu
 On a run without any parameters set, this performs a check for the default keyword (`DO_NOT_SUBMIT`) on **all** files that were modified. 
 No files are ignored.
 If any instances are found, the action will fail.
-```
+```yaml
 name: Run Do Not Submit Action
 on:
   pull_request:
@@ -40,7 +41,7 @@ jobs:
 The following checks in `.go`, `.proto`, and `go.mod` files for the default keyword (`DO_NOT_SUBMIT`). 
 No files are ignored.
 If any instances are found, the action will fail.
-```
+```yaml
 name: Run Do Not Submit Action
 on:
   pull_request:
@@ -60,13 +61,35 @@ jobs:
         check_list: '"*.go,*.proto,go.mod"'
 ```
 
+### Use Case: Checking for ANY instance of the keyword
+The following checks for the default keyword (`DO_NOT_SUBMIT`) in all files that were modified.
+Since `smart_search` is set to `false`, the keyword is searched as-is regardless of the file type.
+```yaml
+name: Run Do Not Submit Action
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Run do-not-submit action
+      uses: infocus7/do-not-submit-action@latest
+      with:
+        smart_search: 'false'
+```
 
 ### Use Case: Specific searches
 The following code searches for the keyword `TODO`.
 All files in the `data` folder, as well as `go.mod` files are searched. 
 The files `data/file_1` and `data/file_2` are ignored, and therefore not searched.
 Since `should_fail` is set to `false`: if any instances of the keyword are found, the Github Action will still pass with a warning.
-```
+```yaml
 name: Run Do Not Submit Action
 on:
   pull_request:
@@ -89,3 +112,8 @@ jobs:
         ignore_list: '"data/file_1,data/file_2"'
         should_fail: 'false'
 ```
+
+## Limitations
+- The action does not support searching for a keyword in a multi-line comment.
+  - A workaround to this is using the `smart_search: false` parameter as shown in the [Checking For Any Instance example](#use-case-checking-for-any-instance-of-the-keyword).
+  - This may not be a good workaround for all cases.

--- a/README.md
+++ b/README.md
@@ -114,5 +114,5 @@ jobs:
 - The action does not support searching for a keyword in a multi-line comment.
   - A workaround to this is using the `smart_search: false` parameter as shown in [Checking For Any Instance](#use-case-checking-for-any-instance-of-the-keyword).
   - This may not be a good workaround for all cases.
-- Due to the nature of regex commands, any parameters using wildcards or special characters (ex. '|'), should be wrapped in quotes.
+- Due to the nature of regex commands, any parameters using wildcards or special characters (ex. '|'), should be wrapped in quotes. So inputs need to be in the form of `'"<value>"'`
   - This is shown in the [Checking For Files Based On File Extensions](#use-case-checking-for-files-based-on-file-extensions) as well as in [Advanced Searches](#use-case-advanced-searches).

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'Whether the action should fail if the keyword is found. If false, the action will succeed even when the keyword is found.'
     required: false
     default: 'true'
+  smart_search:
+    description: 'Whether the keyword should be searched depending on the context. By default, the keyword is searched within file comments depending on the extension. If toggled off, the keyword will be searched as-is within the file.'
+    required: false
+    default: 'true'
   check_list:
     description: 'A list of files to search for the keyword. If using wildcards, be sure to wrap the list in quotes.'
     required: true
@@ -34,4 +38,10 @@ runs:
           fail_type='warn'
         fi
         
-        ${{ github.action_path }}/do-not-submit.sh ${{ inputs.keyword }} "$fail_type" ${{ inputs.check_list }} ${{ inputs.ignore_list }} ${{ steps.changed-files.outputs.all_changed_files }}
+        if [[ ${{ inputs.smart_search }} == 'true' ]]; then
+          search_type='smart'
+        else
+          search_type='simple'
+        fi
+
+        ${{ github.action_path }}/do-not-submit.sh ${{ inputs.keyword }} "$fail_type" "$search_type" ${{ inputs.check_list }} ${{ inputs.ignore_list }} ${{ steps.changed-files.outputs.all_changed_files }}

--- a/do-not-submit.sh
+++ b/do-not-submit.sh
@@ -1,17 +1,18 @@
 #!/bin/bash
 
-# do-not-submit.sh takes the following arguments
+# do-not-submit.sh takes the following arguments:
 # 1. The keyword to cause a failure on
 # 2. Whether the action should pass or fail if a KEYWORD is found ("fail", "warn")
-# 2. A list (as a string) representing which files to check for the keyword.
-# 3. (optional) A list (as a string) representing which files to NOT check for the keyword.
-# 4. A list of modified files to check for the keyword.
+# 3. The type of search to perform ("smart", anything)
+# 4. A list (as a string) representing which files to check for the keyword.
+# 5. (optional) A list (as a string) representing which files to NOT check for the keyword.
+# 6+ Modified files to check for the keyword.
 #
 # If the keyword is present, the script exits with 1.
 # This initial implementation only checks files for single-line comments.
 
-if [[ "$#" -lt 5 ]]; then
-  echo "Usage: $0 keyword failure_type check_list ignore_list filename [filenames ...]"
+if [[ "$#" -lt 6 ]]; then
+  echo "Usage: $0 keyword failure_type search_type check_list ignore_list filename [filenames ...]"
   exit 1
 fi
 
@@ -19,11 +20,17 @@ NEWLINE=$'\n'
 OUTPUT=""
 
 KEYWORD=$1
+# Regardless of failure type we want to exit with 1 so user knows something went wrong.
+if [[ "$KEYWORD" == "" ]]; then
+  echo "::error The keyword MUST NOT be empty. Exiting."
+  exit 1
+fi
 FAILURE_TYPE=$2
-CHECK_LIST=$3
-IGNORE_LIST=$4
+SEARCH_TYPE=$3
+CHECK_LIST=$4
+IGNORE_LIST=$5
 # Gets the rest of the arguments - which should be the list of files - as an array.
-FILES=("${@:5}")
+FILES=("${@:6}")
 
 IFS=',' read -ra check_list_array <<< "$CHECK_LIST"
 IFS=',' read -ra ignore_list_array <<< "$IGNORE_LIST"
@@ -62,23 +69,32 @@ file_matches_check() {
 # TODO: How to handle markdown files? https://www.jamestharpe.com/markdown-comments/
 get_do_not_submit_regex() {
   local filename="$1"
-  # Gets the files extension after the last period. (e.g. "foo.bar.baz" -> "baz")
-  local file_extension="${filename##*.}"
 
-  case $file_extension in
-    go|mod|proto|java|js|ts|cpp|c|php|tsx|jsx)
-      echo "[[:space:]]*//[[:space:]]*$KEYWORD"
-      ;;
-    py)
-      # Separating Python. When adding block comment support, Python has """ ... """ for block comments, which other's don't.
-      echo "[[:space:]]*#[[:space:]]*$KEYWORD"
-      ;;
-    sh|yaml|yml)
-      echo "[[:space:]]*#[[:space:]]*$KEYWORD"
+  case $SEARCH_TYPE in
+    smart)
+      # Gets the files extension after the last period. (e.g. "foo.bar.baz" -> "baz")
+        local file_extension="${filename##*.}"
+
+        case $file_extension in
+          go|mod|proto|java|js|ts|cpp|c|php|tsx|jsx)
+            echo "[[:space:]]*//[[:space:]]*$KEYWORD"
+            ;;
+          py)
+            # Separating Python. When adding block comment support, Python has """ ... """ for block comments, which other's don't.
+            echo "[[:space:]]*#[[:space:]]*$KEYWORD"
+            ;;
+          sh|yaml|yml)
+            echo "[[:space:]]*#[[:space:]]*$KEYWORD"
+            ;;
+          *)
+            # Default case, no matching file extension
+            echo "[[:space:]]*$KEYWORD"
+            ;;
+        esac
       ;;
     *)
-      # Default case, no matching file extension
-      echo "[[:space:]]*$KEYWORD"
+      # Default case, no matching search type, do a simple search for the keyword.
+      echo "$KEYWORD"
       ;;
   esac
 }

--- a/do-not-submit.sh
+++ b/do-not-submit.sh
@@ -102,7 +102,8 @@ get_do_not_submit_regex() {
 for filename in "${FILES[@]}"; do
   if file_matches_check "$filename"; then
     DO_NOT_SUBMIT_REGEX=$(get_do_not_submit_regex "$filename")
-    grep_output=$(grep -Hn "$DO_NOT_SUBMIT_REGEX" "$filename")
+    # Extending grep support with (-E), so that a keyword of "EXAMPLE|DO_NOT_SUBMIT" will match both.
+    grep_output=$(grep -HEn "$DO_NOT_SUBMIT_REGEX" "$filename")
     if [[ -n "$grep_output" ]]; then
       OUTPUT="${OUTPUT}$grep_output${NEWLINE}"
     fi

--- a/do-not-submit.sh
+++ b/do-not-submit.sh
@@ -119,11 +119,15 @@ else
   echo "Usages of $KEYWORD found in the following:"
   echo "$OUTPUT"
 
+  # Get number of instances of the keyword found.
+  num_instances=$(echo "$OUTPUT" | wc -l | tr -d '[:space:]')
+  num_instances=$((num_instances - 1))
+
   if [[ "$FAILURE_TYPE" == "fail" ]]; then
-    echo "::error ::Instances of \"$KEYWORD\" were found in files."
+    echo "::error ::$num_instances instance(s) of \"$KEYWORD\" were found in files."
     exit 1
   elif [[ "$FAILURE_TYPE" == "warn" ]]; then
-    echo "::warning ::Instances of \"$KEYWORD\" were found in files, but the action is configured to warn instead of fail."
+    echo "::warning ::$num_instances instance(s) of \"$KEYWORD\" were found in files."
     exit 0
   fi
 fi

--- a/test/testing.md
+++ b/test/testing.md
@@ -19,3 +19,8 @@ Range (min … max):    9.968 s … 10.563 s    10 runs
 # Conclusion
 From local runs on the above parameters, `grep` is faster and should be used instead of line-by-line reading when searching for `$KEYWORD`.
 If any issues occur due to `grep` in a GitHub action then we can revert, but for now this is the fastest option.
+
+# Updated Note
+
+These tests were run before supporting extended regex in using `grep`. 
+I have not run any performance tests after the fact, and it is very likely that the performance is not as fast anymore - at least when using its features.


### PR DESCRIPTION
In an attempt to allow for block comment searching I found that lookarounds were not supported by bash natively. As a workaround, I added a field `smart_search` to the action. As of now its functions are:

If enabled, we pass `smart` to the script.
If `smart`: Search for keyword in comments.
If not enabled, we pass `simple` (although this value doesn't matter)
If a non-`smart` value is detected in script: Search for keyword anywhere (even within strings)