### PR TITLE
Parameterize script

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,11 +33,15 @@ runs:
       shell: bash
       run: |
         if [[ ${{ inputs.should_fail }} == 'false' ]]; then
-          fail_type='-w'
+          warn_opt='-w'
+        else
+          warn_opt=''
         fi
         
         if [[ ${{ inputs.smart_search }} == 'false' ]]; then
           search_type='-x'
+        else
+          search_type=''
         fi
 
-        ${{ github.action_path }}/do-not-submit.sh -k ${{ inputs.keyword }} "$fail_type" "$search_type" -c ${{ inputs.check_list }} -i ${{ inputs.ignore_list }} ${{ steps.changed-files.outputs.all_changed_files }}
+        ${{ github.action_path }}/do-not-submit.sh -k ${{ inputs.keyword }} "${warn_opt}" "${search_type}" -c ${{ inputs.check_list }} -i ${{ inputs.ignore_list }} ${{ steps.changed-files.outputs.all_changed_files }}

--- a/action.yml
+++ b/action.yml
@@ -32,16 +32,12 @@ runs:
       id: check-files
       shell: bash
       run: |
-        if [[ ${{ inputs.should_fail }} == 'true' ]]; then
-          fail_type='fail'
-        else
-          fail_type='warn'
+        if [[ ${{ inputs.should_fail }} == 'false' ]]; then
+          fail_type='-w'
         fi
         
-        if [[ ${{ inputs.smart_search }} == 'true' ]]; then
-          search_type='smart'
-        else
-          search_type='simple'
+        if [[ ${{ inputs.smart_search }} == 'false' ]]; then
+          search_type='-x'
         fi
 
-        ${{ github.action_path }}/do-not-submit.sh ${{ inputs.keyword }} "$fail_type" "$search_type" ${{ inputs.check_list }} ${{ inputs.ignore_list }} ${{ steps.changed-files.outputs.all_changed_files }}
+        ${{ github.action_path }}/do-not-submit.sh -k ${{ inputs.keyword }} "$fail_type" "$search_type" -c ${{ inputs.check_list }} -i ${{ inputs.ignore_list }} ${{ steps.changed-files.outputs.all_changed_files }}

--- a/action.yml
+++ b/action.yml
@@ -32,16 +32,15 @@ runs:
       id: check-files
       shell: bash
       run: |
+        action="${{ github.action_path }}/do-not-submit.sh -k ${{ inputs.keyword }}"
+
         if [[ ${{ inputs.should_fail }} == 'false' ]]; then
-          warn_opt='-w'
-        else
-          warn_opt=''
+          action+=" -w"
         fi
-        
         if [[ ${{ inputs.smart_search }} == 'false' ]]; then
-          search_type='-x'
-        else
-          search_type=''
+          action+=" -x"
         fi
 
-        ${{ github.action_path }}/do-not-submit.sh -k ${{ inputs.keyword }} "${warn_opt}" "${search_type}" -c ${{ inputs.check_list }} -i ${{ inputs.ignore_list }} ${{ steps.changed-files.outputs.all_changed_files }}
+        action+=" -c ${{ inputs.check_list }} -i ${{ inputs.ignore_list }} ${{ steps.changed-files.outputs.all_changed_files }}"
+
+        eval "$action"

--- a/do-not-submit.sh
+++ b/do-not-submit.sh
@@ -1,36 +1,74 @@
 #!/bin/bash
 
 # do-not-submit.sh takes the following arguments:
-# 1. The keyword to cause a failure on
-# 2. Whether the action should pass or fail if a KEYWORD is found ("fail", "warn")
-# 3. The type of search to perform ("smart", anything)
-# 4. A list (as a string) representing which files to check for the keyword.
-# 5. (optional) A list (as a string) representing which files to NOT check for the keyword.
-# 6+ Modified files to check for the keyword.
-#
-# If the keyword is present, the script exits with 1.
-# This initial implementation only checks files for single-line comments.
+# -k (optional) Keyword to cause failure on. Defaults to "DO_NOT_SUBMIT".
+# -w (optional) If toggled, the script will exit with code 0 (non-failure) when keyword instances are found..
+# -x (optional) If toggled, the search type to perform will be set to search for keyword instances anywhere in the files.
+# -c (optional) <list> A list (as a comma-separated string) representing which files to check for the keyword. Defaults to check all files passed.
+# -i (optional) <list> A list (as a comma-separated string) representing which files to NOT check for the keyword.
+# filenames... A list of modified files to check for the keyword.
 
-if [[ "$#" -lt 6 ]]; then
-  echo "Usage: $0 keyword failure_type search_type check_list ignore_list filename [filenames ...]"
-  exit 1
-fi
+help() {
+  echo "Usage: $0 [-k <keyword>] [-w] [-x] [-c <list>] [-i <list>] filenames..."
+}
+
+# Defaults
+SEARCH_TYPE="smart"
+FAILURE_TYPE="fail"
+CHECK_LIST="*"
+KEYWORD="DO_NOT_SUBMIT"
+IGNORE_LIST=""
 
 NEWLINE=$'\n'
 OUTPUT=""
 
-KEYWORD=$1
-# Regardless of failure type we want to exit with 1 so user knows something went wrong.
+# Parsing command-line options
+while getopts ":k:w:x:c:i:" opt; do
+  case $opt in
+    k)
+      KEYWORD="$OPTARG"
+      ;;
+    w)
+      FAILURE_TYPE="warn"
+      ;;
+    x)
+      SEARCH_TYPE="any"
+      ;;
+    c)
+      CHECK_LIST="$OPTARG"
+      ;;
+    i)
+      IGNORE_LIST="$OPTARG"
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      help
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      help
+      exit 1
+      ;;
+  esac
+done
+
 if [[ "$KEYWORD" == "" ]]; then
   echo "::error The keyword MUST NOT be empty. Exiting."
   exit 1
 fi
-FAILURE_TYPE=$2
-SEARCH_TYPE=$3
-CHECK_LIST=$4
-IGNORE_LIST=$5
-# Gets the rest of the arguments - which should be the list of files - as an array.
-FILES=("${@:6}")
+
+# Shift to skip over processed options
+shift $((OPTIND - 1))
+
+if [[ $# -eq 0 ]]; then
+  echo "No files provided." >&2
+  help
+  exit 1
+fi
+
+# The remaining arguments are the filenames
+FILES=("$@")
 
 IFS=',' read -ra check_list_array <<< "$CHECK_LIST"
 IFS=',' read -ra ignore_list_array <<< "$IGNORE_LIST"

--- a/do-not-submit.sh
+++ b/do-not-submit.sh
@@ -23,7 +23,7 @@ NEWLINE=$'\n'
 OUTPUT=""
 
 # Parsing command-line options
-while getopts ":k:w:x:c:i:" opt; do
+while getopts ":k:wxc:i:" opt; do
   case $opt in
     k)
       KEYWORD="$OPTARG"


### PR DESCRIPTION
Resolves: #11 
Set script inputs to be arguments instead of passed in order.

Essentially want to call `do-not-submit.sh [-k <keyword>] [-w] [-x] [-c <list>] [-i <list>] filenames...`

`-w` toggles warn and doesn't `exit 1` when usages are found.
`-x` toggles the smart/non-smart search.
`-c` is `check_list`
`-i` is `ignore_list`
`-k` is the keyword to be found
and afterward, we provide the files to search

Does not seem to be working as expected through the action call...
https://github.com/inFocus7/do-not-submit-action-tester/pull/1/files